### PR TITLE
Update Step.php

### DIFF
--- a/classes/Delahaye/ConvertX/Dca/Step.php
+++ b/classes/Delahaye/ConvertX/Dca/Step.php
@@ -90,8 +90,10 @@ class Step extends \Backend
 
         $objConverters = ConverterModel::findAll();
 
-        while ($objConverters->next()) {
-            $return[$objConverters->id] = $objConverters->title;
+        if(is_object($objConverters)) {
+            while ($objConverters->next()) {
+                $return[$objConverters->id] = $objConverters->title;
+            }
         }
 
         return $return;


### PR DESCRIPTION
If no convert defined, a fatal error was thrown. Fatal error: Call to a member function next() on a non-object in /system/modules/convertx/classes/Delahaye/ConvertX/Dca/Step.php on line 94
